### PR TITLE
Add scheme parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Sample code
 lane :test do
   bluepill(
     app: 'path/to/SomeApp.app',
+    scheme: 'path/to/SomeApp.xcscheme',
     xctestrun: 'path/to/SomeApp.xctestrun',
     output_dir: 'path/to/output_dir',
     device: 'iPhone 6',

--- a/lib/fastlane/plugin/bluepill/actions/bluepill_action.rb
+++ b/lib/fastlane/plugin/bluepill/actions/bluepill_action.rb
@@ -6,6 +6,7 @@ module Fastlane
         cmd =  bin_bluepill.to_s
         cmd << " #{params[:xctestrun]}"
         cmd << " -a #{params[:app]}"
+        cmd << " -s #{params[:scheme]}"
         cmd << " -o #{params[:output_dir]}"
         cmd << " -d \"#{params[:device]}\""
         cmd << " -n #{params[:number_of_simulators]}"
@@ -43,6 +44,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :output_dir,
                                        env_name: "BLUEPILL_OUTPUT_DIR",
                                        description: "output directory for bluepill logs and reports",
+                                       optional: false,
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :scheme,
+                                       env_name: "BLUEPILL_SCHEME_PATH",
+                                       description: "scheme path (.xcscheme)",
                                        optional: false,
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :app,

--- a/spec/bluepill_action_spec.rb
+++ b/spec/bluepill_action_spec.rb
@@ -5,17 +5,19 @@ describe Fastlane::Actions::BluepillAction do
 
       option_t = "dummy.xctestrun"
       option_a = "dummy.app"
+      option_s = "dummy.xcscheme"
       option_o = "dummy_dir"
       option_d = "iPhone 6"
       option_n = 4
       option_h = true
       option_r = true
 
-      expect(Fastlane::Actions::BluepillAction).to receive(:sh).with("#{Fastlane::Actions::BluepillAction.bin_bluepill} #{option_t} -a #{option_a} -o #{option_o} -d \"#{option_d}\" -n #{option_n} -H --reuse-simulator")
+      expect(Fastlane::Actions::BluepillAction).to receive(:sh).with("#{Fastlane::Actions::BluepillAction.bin_bluepill} #{option_t} -a #{option_a} -s #{option_s} -o #{option_o} -d \"#{option_d}\" -n #{option_n} -H --reuse-simulator")
 
       Fastlane::Actions::BluepillAction.run({
                                               xctestrun: option_t,
                                               app: option_a,
+                                              scheme: option_s,
                                               output_dir: option_o,
                                               device: option_d,
                                               number_of_simulators: option_n,


### PR DESCRIPTION
I noticed there's a `scheme` parameter expect on example code, but in fact, are not using it.

So this PR is to parse the scheme parameter and uses it on bluepill.

TODO: release a new version and might update bluepill bin.